### PR TITLE
fix(payload sanitize):update trim function

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -191,9 +191,9 @@ func (e *errorWriter) WriteError(ctx context.Context, key []byte, errPayload *Er
 }
 
 func sanitizePayload(value []byte) ([]byte, error) {
-
 	trimmedValue := bytes.TrimLeftFunc(value, func(r rune) bool {
-		return !(r == '{' || r == '[' || r == ' ' || r == '\n' || r == '\t' || r == '\r' || (r >= '0' && r <= '9'))
+		// Remove everything until we reach '{' or '[' that come from header of []byte to get exact body
+		return !(r == '{' || r == '[')
 	})
 
 	var temp interface{}


### PR DESCRIPTION
## Jira

## Description
previous function work for specific payload in example 

> "\u0000\u0000\u0000\u0000\u0002h[{\"agent_id\": 1821516, \"membership_package_id\": 50}]"


but wont work for 

> "\u0000\u0000\u0000\u00003h[{\"agent_id\": 1821516, \"membership_package_id\": 50}]"


updated function trimming all left character before found '{' or '['
## Screenshot

if appropriate

## Pull request checklist

- [ ] Unit testing
- [ ] Code documentation
- [x] Build passed on local

## Type of change

- [ ] Refactoring
- [ ] New feature added (non-breaking change)
- [x] Bug fix (non-breaking change)
- [ ] Breaking change
- [ ] Documentation
