### PR TITLE
feat(param): support path param as message key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@ KAFKA_CONSUMER_GROUP_NAME=my-consumer
 KAFKA_SCHEMA_REGISTRY_URL=http://schema-registry:8081/
 HTTP_API_URL=http://localhost:8080/
 HTTP_METHOD=POST
+HTTP_PATH_PARAM=:param

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,11 @@ type Config struct {
 	HttpApiUrl  string      `envconfig:"HTTP_API_URL"`
 	HttpMethod  *string     `envconfig:"HTTP_METHOD"` // Default: POST
 	HttpHeaders *[]string   `envconfig:"HTTP_HEADERS"`
+	// PathParam determines which part of the message key to use as path parameter.
+	// If set, the `:param` placeholder in HttpApiUrl will be replaced with the message key.
+	// Example: HttpApiUrl="http://api.com/v1/users/:param" + message.key="user123"
+	// → "http://api.com/v1/users/user123"
+	HttpPathParam *string `envconfig:"HTTP_PATH_PARAM"`
 }
 
 var cfgSync sync.Once

--- a/internal/processor/processor_test.go
+++ b/internal/processor/processor_test.go
@@ -1,0 +1,228 @@
+package processor
+
+import (
+	"testing"
+)
+
+func TestSubstitutePathParam(t *testing.T) {
+	tests := []struct {
+		name       string
+		url        string
+		paramName  string
+		paramValue string
+		wantURL    string
+		wantErr    bool
+	}{
+		{
+			name:       "valid substitution",
+			url:        "http://api.com/v1/users/:id",
+			paramName:  ":id",
+			paramValue: "user123",
+			wantURL:    "http://api.com/v1/users/user123",
+			wantErr:    false,
+		},
+		{
+			name:       "multiple placeholders",
+			url:        "http://api.com/v1/org/:orgId/users/:id",
+			paramName:  ":id",
+			paramValue: "user456",
+			wantURL:    "http://api.com/v1/org/:orgId/users/user456",
+			wantErr:    false,
+		},
+		{
+			name:       "placeholder not found",
+			url:        "http://api.com/v1/users/profile",
+			paramName:  ":id",
+			paramValue: "user123",
+			wantErr:    true,
+		},
+		{
+			name:       "empty URL",
+			url:        "",
+			paramName:  ":id",
+			paramValue: "user123",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotURL, err := substitutePathParam(tt.url, tt.paramName, tt.paramValue)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("substitutePathParam() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil && gotURL != tt.wantURL {
+				t.Errorf("substitutePathParam() got = %v, want %v", gotURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+func TestSanitizeKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    string
+		isEmpty bool
+	}{
+		{
+			name:    "valid key",
+			input:   []byte("user123"),
+			want:    "user123",
+			isEmpty: false,
+		},
+		{
+			name:    "key with null bytes",
+			input:   []byte("user\x00123"),
+			want:    "user123",
+			isEmpty: false,
+		},
+		{
+			name:    "key with leading/trailing spaces",
+			input:   []byte("  user123  "),
+			want:    "user123",
+			isEmpty: false,
+		},
+		{
+			name:    "key with non-printable characters",
+			input:   []byte("user\x01\x02123"),
+			want:    "user123",
+			isEmpty: false,
+		},
+		{
+			name:    "empty key after sanitization",
+			input:   []byte("\x00\x00\x00"),
+			want:    "",
+			isEmpty: true,
+		},
+		{
+			name:    "key with special characters",
+			input:   []byte("user@123#abc"),
+			want:    "user@123#abc",
+			isEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeKey(tt.input)
+
+			if got != tt.want {
+				t.Errorf("sanitizeKey() got = %q, want %q", got, tt.want)
+			}
+
+			isEmpty := got == ""
+			if isEmpty != tt.isEmpty {
+				t.Errorf("sanitizeKey() isEmpty = %v, want %v", isEmpty, tt.isEmpty)
+			}
+		})
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		baseURL    string
+		pathParam  *string
+		msgKey     []byte
+		wantURL    string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:      "no path parameter configured",
+			baseURL:   "http://api.com/v1/users",
+			pathParam: nil,
+			msgKey:    []byte("user123"),
+			wantURL:   "http://api.com/v1/users",
+			wantErr:   false,
+		},
+		{
+			name:      "valid key with path parameter",
+			baseURL:   "http://api.com/v1/users/:id",
+			pathParam: stringPtr(":id"),
+			msgKey:    []byte("user123"),
+			wantURL:   "http://api.com/v1/users/user123",
+			wantErr:   false,
+		},
+		{
+			name:      "key with special characters (@)",
+			baseURL:   "http://api.com/v1/users/:id",
+			pathParam: stringPtr(":id"),
+			msgKey:    []byte("user@example.com"),
+			wantURL:   "http://api.com/v1/users/user@example.com",
+			wantErr:   false,
+		},
+		{
+			name:      "key with slashes",
+			baseURL:   "http://api.com/v1/users/:id",
+			pathParam: stringPtr(":id"),
+			msgKey:    []byte("path/to/user"),
+			wantURL:   "http://api.com/v1/users/path%2Fto%2Fuser",
+			wantErr:   false,
+		},
+		{
+			name:       "empty key after sanitization",
+			baseURL:    "http://api.com/v1/users/:id",
+			pathParam:  stringPtr(":id"),
+			msgKey:     []byte("\x00\x00\x00"),
+			wantErr:    true,
+			errContain: "empty after sanitization",
+		},
+		{
+			name:       "placeholder not found",
+			baseURL:    "http://api.com/v1/users/profile",
+			pathParam:  stringPtr(":id"),
+			msgKey:     []byte("user123"),
+			wantErr:    true,
+			errContain: "not found in URL",
+		},
+		{
+			name:      "key with null bytes and spaces",
+			baseURL:   "http://api.com/v1/users/:id",
+			pathParam: stringPtr(":id"),
+			msgKey:    []byte("  user\x00123  "),
+			wantURL:   "http://api.com/v1/users/user123",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor := &httpProcessor{
+				url:       tt.baseURL,
+				pathParam: tt.pathParam,
+				logr:      nil, // Using nil logger for test simplicity
+			}
+
+			gotURL, err := processor.parseURL(tt.msgKey)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseURL() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr && tt.errContain != "" && err != nil {
+				if !containsSubstring(err.Error(), tt.errContain) {
+					t.Errorf("parseURL() error message = %q, should contain %q", err.Error(), tt.errContain)
+				}
+			}
+
+			if err == nil && gotURL != tt.wantURL {
+				t.Errorf("parseURL() got = %q, want %q", gotURL, tt.wantURL)
+			}
+		})
+	}
+}
+
+// Helper functions for tests
+func stringPtr(s string) *string {
+	return &s
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && (s == substr || (len(s) >= len(substr) && s[:len(substr)] == substr) || len(s) > len(substr))
+}


### PR DESCRIPTION
## Jira

## Description

Some description on the PR

## Screenshot

if appropriate

## Pull request checklist

- [ ] Unit testing
- [ ] Code documentation
- [ ] Build passed on local

## Type of change

- [ ] Refactoring
- [ ] New feature added (non-breaking change)
- [ ] Bug fix (non-breaking change)
- [ ] Breaking change
- [ ] Documentation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable path-parameter support for HTTP API URLs: a placeholder in the URL can be replaced with the message key at runtime.

* **Bug Fixes**
  * Improved HTTP error handling and error payload formatting when reporting request failures.

* **Documentation**
  * Added the new environment variable to the example env file.

* **Tests**
  * Added unit tests covering URL substitution, key sanitization, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->